### PR TITLE
Output accelerations in m/s^2 as requested in sensor_msgs/Imu doc

### DIFF
--- a/src/node.cpp
+++ b/src/node.cpp
@@ -429,9 +429,9 @@ void imuNode::spin() {
 
 			imu.header.stamp.fromNSec(q.time);
 
-			imu.linear_acceleration.x = -q.ax;
-			imu.linear_acceleration.y = q.ay;
-			imu.linear_acceleration.z = -q.az;
+			imu.linear_acceleration.x = -q.ax * 9.80665;
+			imu.linear_acceleration.y =  q.ay * 9.80665;
+			imu.linear_acceleration.z = -q.az * 9.80665;
 
 			imu.angular_velocity.x = -q.gx;
 			imu.angular_velocity.y = q.gy;


### PR DESCRIPTION
The documentation of [sensor_msgs/Imu](http://docs.ros.org/api/sensor_msgs/html/msg/Imu.html) states:

> Accelerations should be in m/s^2 (not in g's), and rotational velocity should be in rad/sec

This PR adds the conversion to follow this convention.